### PR TITLE
Fix error with Android Pie

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -25,7 +25,7 @@ android {
     }
     buildTypes {
         debug {
-            applicationIdSuffix ".debug"
+            applicationIdSuffix ".debug" //allow to install 2 version of the full or demo app's version on the same device
         }
         release {
             minifyEnabled false

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -24,6 +24,9 @@ android {
         }
     }
     buildTypes {
+        debug {
+            applicationIdSuffix ".debug"
+        }
         release {
             minifyEnabled false
             proguardFiles getDefaultProguardFile('proguard-android.txt'), 'proguard-rules.pro'

--- a/app/src/debug/res/values/strings.xml
+++ b/app/src/debug/res/values/strings.xml
@@ -1,5 +1,0 @@
-<resources
-    xmlns:tools="http://schemas.android.com/tools"
-    tools:ignore="Typos">
-    <string name="app_name">Gladys Debug</string>
-</resources>

--- a/app/src/debug/res/values/strings.xml
+++ b/app/src/debug/res/values/strings.xml
@@ -1,0 +1,5 @@
+<resources
+    xmlns:tools="http://schemas.android.com/tools"
+    tools:ignore="Typos">
+    <string name="app_name">Gladys Debug</string>
+</resources>

--- a/app/src/full/java/com/gladysproject/gladys/fragments/HomeFragment.kt
+++ b/app/src/full/java/com/gladysproject/gladys/fragments/HomeFragment.kt
@@ -7,6 +7,7 @@ import android.support.design.widget.Snackbar
 import android.support.v4.app.Fragment
 import android.support.v7.widget.LinearLayoutManager
 import android.support.v7.widget.SimpleItemAnimator
+import android.util.Log
 import android.view.*
 import com.gladysproject.gladys.R
 import com.gladysproject.gladys.adapters.DeviceTypeAdapter
@@ -31,7 +32,6 @@ import retrofit2.Callback
 import retrofit2.Response
 import retrofit2.Retrofit
 import retrofit2.converter.moshi.MoshiConverterFactory
-import java.lang.Exception
 
 class HomeFragment : Fragment(), AdapterCallback.AdapterCallbackDeviceState{
 
@@ -44,6 +44,7 @@ class HomeFragment : Fragment(), AdapterCallback.AdapterCallbackDeviceState{
 
     companion object {
         fun newInstance() = HomeFragment()
+        private const val TAG = "HomeFragment"
     }
 
     override fun onCreateView(inflater: LayoutInflater, container: ViewGroup?, savedInstanceState: Bundle?): View? {
@@ -146,6 +147,8 @@ class HomeFragment : Fragment(), AdapterCallback.AdapterCallbackDeviceState{
                     }
 
                     override fun onFailure(call: Call<MutableList<Rooms>>, err: Throwable) = runBlocking {
+                        // Log the error for debug
+                        Log.e(TAG, err.message)
                         GlobalScope.launch {
                             val rooms : MutableList<Rooms> = GladysDb.database?.roomsDao()?.getAllRooms()!!
                             for (room in rooms){

--- a/app/src/main/java/com/gladysproject/gladys/utils/ConnectivityAPI.kt
+++ b/app/src/main/java/com/gladysproject/gladys/utils/ConnectivityAPI.kt
@@ -52,6 +52,7 @@ class ConnectivityAPI {
                 // for Android P and above, cleartext traffic are not allowed
                 // see more at : https://android-developers.googleblog.com/2018/04/protecting-users-with-tls-by-default-in.html
                 httpOrHttps = "https"
+                //check port number just to be sure to not use default HTTP port...
                 portNb = if (portNb == "8080" || portNb == "80") { "443" /*default port for HTTPS*/ } else { portNb }
             }
 
@@ -101,11 +102,19 @@ class ConnectivityAPI {
          Building the URL according to the type of connection
          */
         fun getUrl(context: Context): String {
-            return when(getTypeOfConnection(context)){
+            var url = when(getTypeOfConnection(context)){
                 1 -> ConnectivityAPI.getLocalPreferences(context)
                 2 -> ConnectivityAPI.getNatPreferences(context)
                 else -> "http://noconnection"
             }
+
+            if (android.os.Build.VERSION.SDK_INT >= android.os.Build.VERSION_CODES.P && url.startsWith("http://")) {
+                // for Android P and above, cleartext traffic are not allowed
+                // see more at : https://android-developers.googleblog.com/2018/04/protecting-users-with-tls-by-default-in.html
+                url.replace("http://", "https://")
+            }
+
+            return url
         }
 
         /**

--- a/app/src/main/java/com/gladysproject/gladys/utils/ConnectivityAPI.kt
+++ b/app/src/main/java/com/gladysproject/gladys/utils/ConnectivityAPI.kt
@@ -45,7 +45,19 @@ class ConnectivityAPI {
         */
         private fun getLocalPreferences(context: Context) : String {
             val prefs = PreferenceManager.getDefaultSharedPreferences(context)
-            return if(prefs.getString("local_ip", "fakeurl") != "") "http://${prefs.getString("local_ip", "fakeurl")}:${prefs.getString("local_port", "8080")}/" else "http://fakeurl"
+            var portNb = prefs.getString("local_port", "8080")
+            var httpOrHttps = "http"
+
+            if (android.os.Build.VERSION.SDK_INT >= android.os.Build.VERSION_CODES.P) {
+                // for Android P and above, cleartext traffic are not allowed
+                // see more at : https://android-developers.googleblog.com/2018/04/protecting-users-with-tls-by-default-in.html
+                httpOrHttps = "https"
+                portNb = if (portNb == "8080" || portNb == "80") { "443" /*default port for HTTPS*/ } else { portNb }
+            }
+
+            val localIp = prefs.getString("local_ip", "fakeurl")
+
+            return if(localIp != "") "$httpOrHttps://$localIp:$portNb/" else "http://fakeurl"
         }
 
         /**


### PR DESCRIPTION
For Android P and above, cleartext traffic are not allowed.
See more at : https://android-developers.googleblog.com/2018/04/protecting-users-with-tls-by-default-in.html

My fix could not be the best way to do it (for external access for example, user can still think he could use HTTP instead of HTTPS), but it's first step and we can discuss about how to make it greater.